### PR TITLE
fix: make TPM and procfs dependencies optional for macOS compatibility

### DIFF
--- a/form-node-metrics/Cargo.toml
+++ b/form-node-metrics/Cargo.toml
@@ -30,8 +30,10 @@ form-config = { path = "../form-config" }
 form-p2p = { path = "../form-p2p" }
 
 [features]
+default = []
 intel = ["sgx"]
 amd = ["sev"]
+tpm = ["tss2"]
 
 [dependencies.sgx]
 version = "0.6"
@@ -43,3 +45,4 @@ optional = true
 
 [dependencies.tss2]
 version = "0.1"
+optional = true

--- a/form-vm-metrics/Cargo.toml
+++ b/form-vm-metrics/Cargo.toml
@@ -6,9 +6,11 @@ edition = "2021"
 [dependencies]
 sysinfo = "0.33"
 nvml-wrapper = "0.9"
-procfs = { git = "http://github.com/cryptonomikhan/procfs", rev = "9b414a4", features = ["serde1"] } 
 clap = { version = "4.5", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
-serde = { version = "1", features = ["derive"] }
-serde_json = { version = "1", features = ["preserve_order"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 axum = { version = "0.7", features = ["tokio"] }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+procfs = { git = "http://github.com/cryptonomikhan/procfs", rev = "9b414a4", features = ["serde1"] }

--- a/form-vm-metrics/src/system.rs
+++ b/form-vm-metrics/src/system.rs
@@ -1,26 +1,30 @@
 use std::{sync::Arc, time::{SystemTime, UNIX_EPOCH}};
 use tokio::sync::Mutex;
-use procfs::DiskStat;
 use serde::{Serialize, Deserialize};
 use sysinfo::System;
 
-use crate::{cpu::{collect_cpu, CpuMetrics}, disk::{collect_disks, DiskMetrics}, gpu::{collect_gpu_metrics, GpuMetrics}, load::{collect_load_metrics, LoadMetrics}, mem::{collect_memory, MemoryMetrics}, network::{collect_network_metrics, NetworkMetrics}};
+use crate::{
+    cpu::{collect_cpu, CpuMetrics}, 
+    disk::{collect_disk_metrics, DiskMetrics}, 
+    gpu::{collect_gpu_metrics, GpuMetrics}, 
+    load::{collect_load_metrics, LoadMetrics}, 
+    mem::{collect_memory, MemoryMetrics}, 
+    network::{collect_network_metrics, NetworkMetrics}
+};
 
-#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct SystemMetrics {
     pub timestamp: i64,
     pub cpu: CpuMetrics,
     pub memory: MemoryMetrics,
     pub disks: Vec<DiskMetrics>,
-    pub disk_stats: Vec<DiskStat>,
-    pub gpus: Vec<GpuMetrics>,
     pub network: NetworkMetrics,
+    pub gpus: Vec<GpuMetrics>,
     pub load: LoadMetrics,
 }
 
-pub async fn collect_system_metrics(
+pub async fn collect_system_metrics_async(
     system_metrics: Arc<Mutex<SystemMetrics>>,
-    disk_stats: Option<Vec<DiskStat>>,
     refresh: u64,
 ) -> Arc<Mutex<SystemMetrics>> {
     let mut sys = System::new_all();
@@ -28,23 +32,24 @@ pub async fn collect_system_metrics(
 
     let cpu = collect_cpu(&mut sys).await;
     let memory = collect_memory(&mut sys).await;
-    let (metrics, stats) = collect_disks(disk_stats, refresh).await;
+    let disks = collect_disk_metrics();
     let network = collect_network_metrics();
     let gpus = collect_gpu_metrics().await.unwrap_or_else(|e| {
         eprintln!("Failed to collect GPU metrics: {}", e);
         Vec::new()
     });
     let load = collect_load_metrics();
-    let timestamp = SystemTime::now().duration_since(UNIX_EPOCH).expect("Something is seriously wrong with the system").as_secs() as i64;
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("Something is seriously wrong with the system")
+        .as_secs() as i64;
 
     let mut guard = system_metrics.lock().await;
-
     *guard = SystemMetrics {
         timestamp,
         cpu,
         memory,
-        disks: metrics,
-        disk_stats: stats,
+        disks,
         network,
         gpus,
         load,


### PR DESCRIPTION
- Made tss2 dependency optional with tpm feature flag

- Made procfs dependency Linux-only

- Added cross-platform disk metrics collection

- Fixed system metrics collection for non-Linux platforms